### PR TITLE
DUP-28: Removed `version` key from library

### DIFF
--- a/iq_whitepaper.libraries.yml
+++ b/iq_whitepaper.libraries.yml
@@ -1,5 +1,4 @@
 file_download:
-  version: VERSION
   js:
     resources/js/file_download.js: {}
   dependencies:


### PR DESCRIPTION
We have `version: VERSION` set in our `*.libraries.yml` which leads to aggregated files always having the same hash and thus it is not guaranteed that cache is busted for clients/browsers. Remove it to solve the issue.